### PR TITLE
Update Static CMS event datetime formats to allow offsets

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -87,7 +87,7 @@ collections:
         name: lastUpdated
         widget: datetime
         required: false
-        format: YYYY-MM-DDTHH:mm:ss[Z]
+        format: YYYY-MM-DDTHH:mm:ssZ
         picker_utc: true
         read_only: true
       - label: Synced Events
@@ -102,14 +102,14 @@ collections:
           - label: Start Date
             name: startDate
             widget: datetime
-            format: YYYY-MM-DDTHH:mm:ss[Z]
+            format: YYYY-MM-DDTHH:mm:ssZ
             picker_utc: true
             read_only: true
           - label: End Date
             name: endDate
             widget: datetime
             required: false
-            format: YYYY-MM-DDTHH:mm:ss[Z]
+            format: YYYY-MM-DDTHH:mm:ssZ
             picker_utc: true
             read_only: true
           - label: Location


### PR DESCRIPTION
## Summary
- replace the Static CMS datetime formats for event timestamps to accept timezone offsets

## Testing
- npm run build:eleventy

------
https://chatgpt.com/codex/tasks/task_e_68dcdfa058948331bcc176579428e47e